### PR TITLE
maint: remove `zplugin` references

### DIFF
--- a/zp-test-handler
+++ b/zp-test-handler
@@ -18,7 +18,7 @@ setopt extendedglob warncreateglobal typesetsilent noshortloops
             [[ "${OPTS[opt_-q,--quiet]}" != 1 ]] && \
                 print -P -- "%F{38}zinit-annex-test: %F{154}RUNNING MAKEFILE TESTS%f"
             integer quiet=0
-            zstyle -T ":zplugin:annex:test" quiet && quiet=1
+            zstyle -T ":zinit:annex:test" quiet && quiet=1
             if (( quiet )); then
                 if make test &>/dev/null; then
                     [[ "${OPTS[opt_-q,--quiet]}" != 1 ]] && \
@@ -39,7 +39,7 @@ setopt extendedglob warncreateglobal typesetsilent noshortloops
             [[ "${OPTS[opt_-q,--quiet]}" != 1 ]] && \
                 print -P -- "%F{38}zinit-annex-test: %F{154}RUNNING ZUNIT TESTS%f"
             integer quiet=0
-            zstyle -T ":zplugin:annex:test" quiet && quiet=1
+            zstyle -T ":zinit:annex:test" quiet && quiet=1
             if (( quiet )); then
                 if zunit &>/dev/null; then
                     [[ "${OPTS[opt_-q,--quiet]}" != 1 ]] && \
@@ -54,7 +54,7 @@ setopt extendedglob warncreateglobal typesetsilent noshortloops
         else
             [[ "${OPTS[opt_-q,--quiet]}" != 1 ]] && \
                 print -P -- "%F{38}zinit-annex-test: %F{154}Please install zunit-zsh/zunit to" \
-                   " run the zunit tests provided with the plugin%f"
+                    " run the zunit tests provided with the plugin%f"
         fi
     fi
 )


### PR DESCRIPTION
`zplugin` has no relevance and IMHO references to it are safe to retire.